### PR TITLE
use the standard library mock if available

### DIFF
--- a/tests/tests_common_file_inject.py
+++ b/tests/tests_common_file_inject.py
@@ -5,9 +5,14 @@ from novaagent.common import file_inject
 
 import base64
 import shutil
-import mock
 import glob
 import os
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestHelpers(TestCase):

--- a/tests/tests_common_kms.py
+++ b/tests/tests_common_kms.py
@@ -3,9 +3,14 @@ from novaagent.common import kms
 from unittest import TestCase
 from .fixtures import kms_data
 
-import mock
 import glob
 import os
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestHelpers(TestCase):

--- a/tests/tests_common_password.py
+++ b/tests/tests_common_password.py
@@ -4,10 +4,15 @@ from novaagent.common import password
 
 
 import base64
-import mock
 import glob
 import sys
 import os
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 if sys.version_info > (3,):

--- a/tests/tests_init.py
+++ b/tests/tests_init.py
@@ -3,7 +3,12 @@ from unittest import TestCase
 from novaagent import libs
 
 import novaagent
-import mock
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestHelpers(TestCase):

--- a/tests/tests_libs_centos.py
+++ b/tests/tests_libs_centos.py
@@ -5,9 +5,14 @@ from .fixtures import network
 from unittest import TestCase
 
 
-import mock
 import glob
 import os
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestHelpers(TestCase):

--- a/tests/tests_libs_debian.py
+++ b/tests/tests_libs_debian.py
@@ -5,9 +5,14 @@ from .fixtures import network
 from unittest import TestCase
 
 
-import mock
 import glob
 import os
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestHelpers(TestCase):

--- a/tests/tests_libs_redhat.py
+++ b/tests/tests_libs_redhat.py
@@ -3,7 +3,10 @@ from novaagent.libs import redhat
 from unittest import TestCase
 
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestHelpers(TestCase):

--- a/tests/tests_novaagent.py
+++ b/tests/tests_novaagent.py
@@ -4,8 +4,13 @@ from unittest import TestCase
 
 
 import novaagent
-import mock
 import time
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestHelpers(TestCase):

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -3,10 +3,14 @@ from unittest import TestCase
 from .fixtures import xen_data
 from novaagent import utils
 
-
-import mock
 import glob
 import os
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class ClientTest(object):


### PR DESCRIPTION
I'm not 100% sure this will work but mock is in the [standard library since 3.3](https://docs.python.org/3.3/library/unittest.mock.html).  If it does work then that is one less build requirement for packaging when using PY3.