### PR TITLE
use unittest2 on Python 2.6

### DIFF
--- a/tests/tests_common_file_inject.py
+++ b/tests/tests_common_file_inject.py
@@ -1,12 +1,18 @@
 
-from unittest import TestCase
 from novaagent.common import file_inject
 
 
 import base64
 import shutil
+import sys
 import glob
 import os
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
 
 
 try:

--- a/tests/tests_common_kms.py
+++ b/tests/tests_common_kms.py
@@ -1,10 +1,16 @@
 
 from novaagent.common import kms
-from unittest import TestCase
 from .fixtures import kms_data
 
 import glob
 import os
+import sys
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
 
 
 try:

--- a/tests/tests_common_password.py
+++ b/tests/tests_common_password.py
@@ -1,5 +1,4 @@
 
-from unittest import TestCase
 from novaagent.common import password
 
 
@@ -7,6 +6,12 @@ import base64
 import glob
 import sys
 import os
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
 
 
 try:

--- a/tests/tests_init.py
+++ b/tests/tests_init.py
@@ -1,14 +1,23 @@
 
-from unittest import TestCase
 from novaagent import libs
 
 import novaagent
+import sys
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
 
 
 try:
     from unittest import mock
 except ImportError:
     import mock
+
+
+
 
 
 class TestHelpers(TestCase):

--- a/tests/tests_libs_centos.py
+++ b/tests/tests_libs_centos.py
@@ -2,11 +2,17 @@
 from novaagent.libs import centos
 from .fixtures import xen_data
 from .fixtures import network
-from unittest import TestCase
 
 
 import glob
 import os
+import sys
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
 
 
 try:

--- a/tests/tests_libs_debian.py
+++ b/tests/tests_libs_debian.py
@@ -2,11 +2,17 @@
 from novaagent.libs import debian
 from .fixtures import xen_data
 from .fixtures import network
-from unittest import TestCase
 
 
 import glob
 import os
+import sys
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
 
 
 try:

--- a/tests/tests_libs_redhat.py
+++ b/tests/tests_libs_redhat.py
@@ -1,6 +1,14 @@
 
 from novaagent.libs import redhat
-from unittest import TestCase
+
+
+import sys
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
 
 
 try:

--- a/tests/tests_novaagent.py
+++ b/tests/tests_novaagent.py
@@ -1,10 +1,16 @@
 
 from novaagent.libs import centos
-from unittest import TestCase
 
 
 import novaagent
 import time
+import sys
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
 
 
 try:

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -1,10 +1,16 @@
 
-from unittest import TestCase
 from .fixtures import xen_data
 from novaagent import utils
 
 import glob
 import os
+import sys
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
 
 
 try:

--- a/tests/tests_xenbus.py
+++ b/tests/tests_xenbus.py
@@ -3,8 +3,14 @@ from pyxs.client import Client
 from pyxs.connection import XenBusConnection
 
 
-from unittest import TestCase
 from novaagent import xenbus
+import sys
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
 
 
 class TestXenBus(TestCase):


### PR DESCRIPTION
Python 2.6's `unittest.TestCase` does not have an `assertIn` method.  unittest2 is a backport of Python 2.7's unittest module.  There are more Python 2.6 fixes needed, but this is a start.