### PR TITLE
positional argument specifier is required in Python 2.6

### DIFF
--- a/novaagent/libs/debian.py
+++ b/novaagent/libs/debian.py
@@ -164,7 +164,7 @@ class ServerOS(DefaultOS):
             if p.returncode != 0:
                 return (
                     str(p.returncode),
-                    'Error stopping network: {}'.format(ifname)
+                    'Error stopping network: {0}'.format(ifname)
                 )
 
             # Sleep for one second
@@ -179,7 +179,7 @@ class ServerOS(DefaultOS):
             if p.returncode != 0:
                 return (
                     str(p.returncode),
-                    'Error starting network: {}'.format(ifname)
+                    'Error starting network: {0}'.format(ifname)
                 )
 
         return ('0', '')

--- a/tests/tests_common_password.py
+++ b/tests/tests_common_password.py
@@ -361,7 +361,7 @@ class TestHelpers(TestCase):
             password.set_password('testuser', 'test')
         except Exception as e:
             assert False, (
-                'Exception raised when should not have: {}'.format(e)
+                'Exception raised when should not have: {0}'.format(e)
             )
 
         files = glob.glob('/tmp/passwd*')

--- a/tests/tests_libs_centos.py
+++ b/tests/tests_libs_centos.py
@@ -37,7 +37,7 @@ class TestHelpers(TestCase):
             f.write('This is a test file')
 
     def setup_temp_interface_config(self, interface):
-        with open('/tmp/ifcfg-{}'.format(interface), 'a+') as f:
+        with open('/tmp/ifcfg-{0}'.format(interface), 'a+') as f:
             f.write('This is a test file')
 
     def setup_temp_hostname(self):


### PR DESCRIPTION
Fixes multiple `ValueError: zero length field name in format` errors.